### PR TITLE
Add nodate page font matter variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,10 @@ Hide page from the mainSection of the homepage.
 
 Disallow page in robots.txt for search engines.
 
+**nodate(bool)**
+
+Hide the publish date of the page. Useful for about pages or pages required for legal reasons.
+
 ## Credits
 
 * [hugo-ink](https://github.com/knadh/hugo-ink) from which Vitae was forked

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -16,10 +16,12 @@
 <div class="post-header">
 {{ if ne .Date.Year 1 }}
 <div class="meta">
+{{ if not .Params.nodate }}
 <div class="date">
 <span class="day">{{ dateFormat "02" .Date }}</span>
 <span class="rest">{{ if $.Site.Data.month }}{{ index $.Site.Data.month (printf "%d" .Date.Month) }} {{ .Date.Year }}{{ else }}{{ dateFormat "Jan 2006" .Date }}{{ end }}</span>
 </div>
+{{ end }}
 </div>
 {{ end }}
 <div class="matter">


### PR DESCRIPTION
If the variable `nodate` is set to true, the publish date of the article
is not shown. This is useful for about pages.

Fixes #12