### PR TITLE
Ignore Google Analytics when developing locally

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,3 +8,4 @@ collaboration of others.
 * [Benedikt Tuchen](https://github.com/dataCobra)
 * [Mark Petherbridge](https://github.com/markdevjapan)
 * [Christoph Petrausch](https://github.com/hikhvar)
+* [Mohamed Muhannad](https://github.com/muhannad0)

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,5 +1,7 @@
 <footer>
 {{ with .Site.Copyright }} {{ . | markdownify }} {{ end }}
 
-{{ template "_internal/google_analytics_async.html" . }}
+{{ if not .Site.IsServer }}
+    {{ template "_internal/google_analytics_async.html" . }}
+{{ end }}
 </footer>


### PR DESCRIPTION
Hi.

I noticed that if Google Analytics is set in config.toml, all page loads are logged to GA when running the site locally for development. So I added an extra check to see if it's running on local server (for example: hugo server) and add the GA code based on that.

I think this would be useful to keep the production analytics unaffected when doing local development.

Thanks.