### PR TITLE
Links with target _blank as default

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,0 +1,3 @@
+<a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if strings.HasPrefix .Destination "http" }} target="_blank"{{ end }}>
+  {{ .Text }}
+</a>


### PR DESCRIPTION
A folder called `_markup` was added inside the `_default` folder in order to customize how links are rendered.

Now all links have the attribute target="_blank" by default so they open in a new tab.

Closes #36 