### PR TITLE
Render images inside <figure> tags

### DIFF
--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -1,0 +1,3 @@
+<figure>
+  <img src="{{ .Destination | safeURL }}" alt="{{ .Text }}" {{ with .Title}} title="{{ . }}"{{ end }} />
+</figure>


### PR DESCRIPTION
This change adds an extra file called `render-image.html` inside `_markup`  folder in order to render images inside `figure` tags instead of `p` tags.

```bash
layouts
└── _default
    └── _markup
        ├── render-image.html
        └── render-link.html
```

Closes #38 