### PR TITLE
Bugfix: Instagram shortcode in Example Site breaks the site

### DIFF
--- a/exampleSite/content/post/rich-content.md
+++ b/exampleSite/content/post/rich-content.md
@@ -13,14 +13,6 @@ Hugo ships with several [Built-in Shortcodes](https://gohugo.io/content-manageme
 <!--more-->
 ---
 
-## Instagram Simple Shortcode
-
-{{< instagram_simple BGvuInzyFAe hidecaption >}}
-
-<br>
-
----
-
 ## YouTube Privacy Enhanced Shortcode
 
 {{< youtube ZJthWmvUzzc >}}


### PR DESCRIPTION
This Pull Request will fix the bug caused by Facebook blocking access to Instagram public API discussed on Issue #53


fixes #53