### PR TITLE
Fix customcss

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -66,7 +66,7 @@
 	</script>
 	{{- end -}}
 	<!-- Use customCSS if you like -->
-	{{- if isset .Site.Params "customCSS" -}}
+	{{- if isset .Site.Params "customcss" -}}
 	<link rel="stylesheet" type="text/css" media="screen" href="{{ relURL .Site.Params.customCSS }}" />
 	{{- end -}}
 	<!-- Use a SEO friendly title tag-->


### PR DESCRIPTION
Absolutely sry to bug you with this 😢 
I introduced this error myself when implementing customjs parameter 😭 😭 😭 
> All site-level configuration keys are stored as lower case.

Source:  [official documentation](https://gohugo.io/functions/isset/)

