### PR TITLE
Show dark mode toggle when social links are not specified

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -17,3 +17,4 @@ collaboration of others.
 * [David Kaufmann](https://github.com/davidkaufmann)
 * [Sarath Chandra Mekala](https://github.com/sarathmekala)
 * [Jeff Schoner](https://github.com/jeffschoner)
+* [Leo Qi](https://github.com/leozqi)

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -25,9 +25,9 @@
 {{- else }}
 <div id="title-social">
 {{- end }}
-{{- if isset .Site.Params "social" }}
 <div id="social">
 <nav><ul>
+{{- if isset .Site.Params "social" }}
 {{- range $index, $key := .Site.Params.Social }}
 {{- if $key.url }}
 <li><a href="{{ relURL $key.url }}"><i title="{{ $key.name }}" class="icons {{ $key.icon }}"></i></a></li>
@@ -35,10 +35,10 @@
 <li><a href="{{ $key.cmd }}"><i title="{{ $key.name }}" class="icons {{ $key.icon }}"></i></a></li>
 {{- end }}
 {{- end }}
+{{- end }}
 <li><a><i title="Switch Dark Mode" class="dark-mode icons fas fa-moon"></i></a></li>
 </ul></nav>
 </div>
-{{- end }}
 </div>
 {{- if isset .Site.Menus "main" }}
 <div id="mainmenu">


### PR DESCRIPTION
This pull request should allow the dark mode toggle (sun/moon icon) to be displayed even when no other social links are specified.

Fixes #78