### PR TITLE
Added post labeling partial.

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -19,7 +19,7 @@
 </div>
 <div class="matter">
 <article>
-<h3 class="title small"><a href="{{ .RelPermalink }}">{{.Title}}{{ if .Draft }}<sup class="draft-label">DRAFT</sup>{{ end }}</a></h3>
+<h3 class="title small"><a href="{{ .RelPermalink }}">{{.Title}}{{ partial "post_label.html" (dict "post" .)}}</a></h3>
 {{- if not .Params.hidemeta }}
 <p class="post-meta">
 {{ partial "post_meta.html" . }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -18,7 +18,7 @@
 </div>
 {{- end }}
 <div class="matter">
-<h1 class="title">{{ .Title }}</h1>
+<h1 class="title">{{ .Title }}{{ partial "post_label.html" (dict "post" .) }}</h1>
 {{- if not .Params.hidemeta }}
 <p class="post-meta">
 {{ partial "post_meta.html" . }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -64,7 +64,7 @@
 </div>
 <div class="matter">
 <article>
-<h3 class="title small"><a href="{{ .RelPermalink }}">{{.Title}}{{ if .Draft }}<sup class="draft-label">DRAFT</sup>{{ end }}</a></h3>
+<h3 class="title small"><a href="{{ .RelPermalink }}">{{.Title}}{{partial "post_label.html" (dict "post" .)}}</a></h3>
 {{- if not .Params.hidemeta }}
 <p class="post-meta">
 {{ partial "post_meta.html" . }}

--- a/layouts/partials/post_label.html
+++ b/layouts/partials/post_label.html
@@ -1,0 +1,1 @@
+{{ if .post.Draft }}<sup class="draft-label">DRAFT</sup>{{ end }}{{ if gt .post.Date now }}<sup class="draft-label">FUTURE</sup>{{ end }}


### PR DESCRIPTION
I've been using this patch on my personal site for a little while and I thought it might be useful for other users of this theme.

This change provides a `post_label` partial that shows a consistent badge throughout the site indicating the draft and future status of posts. Previously the draft status of a post was not shown when directly viewing the post, only when it was shown in a list view.

The future indication label is a feature I added to add some visual clarity about what posts are or are not going to be visible during a "production" build of the site.

**Before**:

Homepage:
![homepage-before](https://user-images.githubusercontent.com/31573882/136234949-dd7e5981-07aa-46df-893a-80e35b5c8519.png)

Post:
![post-before](https://user-images.githubusercontent.com/31573882/136235071-777ae0b6-0a92-493c-a479-e13bf4c26bc4.png)

**After**:

Homepage:
![homepage-after](https://user-images.githubusercontent.com/31573882/136235112-32deb037-c415-4882-91de-9492e527c877.png)

Post:
![post-after](https://user-images.githubusercontent.com/31573882/136235134-bba0b91f-89fd-430c-b0de-19f2260a6a5b.png)


