### PR TITLE
fix inability to change themes when media query 'prefers-color-scheme: dark is set

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -64,21 +64,6 @@
   --inline-cd-color: #37342E;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --bg-color: #181714;
-    --txt-color: #FFEECA;
-    --line-color: #433F37;
-    --fn-color: #534F47;
-    --ft-txt-color: #FFEECA;
-    --lk-color: #8192AE;
-    --hover-color: #B1A184;
-    --bq-color: #75271E;
-    --tb1-color: #47443B;
-    --inline-cd-color: #37342E;
-  }
-}
-
 html {
   background-color: var(--bg-color);
 }

--- a/static/js/dark-mode.js
+++ b/static/js/dark-mode.js
@@ -30,3 +30,11 @@ function switchTheme() {
 }
 
 toggleSwitch.addEventListener('click', switchTheme, false);
+
+window.onload = function() {
+    if (window.matchMedia("(prefers-color-scheme: dark)").matches && !localStorage.getItem('prefers-color-scheme-dark')) {
+        localStorage.setItem('theme', 'light');
+        switchTheme();
+        localStorage.setItem('prefers-color-scheme-dark', true);
+    }
+};


### PR DESCRIPTION
removes media query 'prefers-color-scheme: dark', because it overrides
light theme root variables. added new localstorage variable that checks
for preference and if it has been set to dark before. not adding this
check would result in random theme switches.