### PR TITLE
Add rel=me attribute to social icons

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -30,7 +30,7 @@
 <nav><ul>
 {{- range $index, $key := .Site.Params.Social }}
 {{- if $key.url }}
-<li><a href="{{ relURL $key.url }}"><i title="{{ $key.name }}" class="icons {{ $key.icon }}"></i></a></li>
+<li><a href="{{ relURL $key.url }}" rel="me"><i title="{{ $key.name }}" class="icons {{ $key.icon }}"></i></a></li>
 {{- else }}
 <li><a href="{{ $key.cmd }}"><i title="{{ $key.name }}" class="icons {{ $key.icon }}"></i></a></li>
 {{- end }}


### PR DESCRIPTION
This attribute is used by many tools like mastodon to check if a website belongs to a certain user profile.

Details can be found here: https://microformats.org/wiki/rel-me