### PR TITLE
Improve accessibility

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -18,3 +18,4 @@ collaboration of others.
 * [Sarath Chandra Mekala](https://github.com/sarathmekala)
 * [Jeff Schoner](https://github.com/jeffschoner)
 * [Leo Qi](https://github.com/leozqi)
+* [Konrad Borowski](https://github.com/xfix)

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -70,7 +70,7 @@
 {{ partial "post_meta.html" . }}
 </p>
 {{- end }}
-<span class="description">{{ if isset .Params "description" }}{{ .Description }}{{ else }}{{ .Plain | htmlUnescape | safeHTML | truncate 140 }}{{ end }}</span>
+<p class="description">{{ if isset .Params "description" }}{{ .Description }}{{ else }}{{ .Plain | htmlUnescape | safeHTML | truncate 140 }}{{ end }}</p>
 </article>
 </div>
 </div>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -36,7 +36,7 @@
 {{- end }}
 {{- end }}
 {{- end }}
-<li><a><i title="Switch Dark Mode" class="dark-mode icons fas fa-moon"></i></a></li>
+<li><button id="dark-mode" aria-label="Switch Dark Mode"><span title="Switch Dark Mode" class="icons fas fa-moon" aria-hidden="true"></span></button></li>
 </ul></nav>
 </div>
 </div>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -30,9 +30,9 @@
 {{- if isset .Site.Params "social" }}
 {{- range $index, $key := .Site.Params.Social }}
 {{- if $key.url }}
-<li><a href="{{ relURL $key.url }}" rel="me"><i title="{{ $key.name }}" class="icons {{ $key.icon }}"></i></a></li>
+<li><a href="{{ relURL $key.url }}" rel="me" aria-label="{{ $key.name }}"><span title="{{ $key.name }}" class="icons {{ $key.icon }}" aria-hidden="true"></span></a></li>
 {{- else }}
-<li><a href="{{ $key.cmd | safeURL }}"><i title="{{ $key.name }}" class="icons {{ $key.icon }}"></i></a></li>
+<li><a href="{{ $key.cmd | safeURL }}" aria-label="{{ $key.name }}"><span title="{{ $key.name }}" class="icons {{ $key.icon }}" aria-hidden="true"></span></a></li>
 {{- end }}
 {{- end }}
 {{- end }}

--- a/layouts/partials/post_meta.html
+++ b/layouts/partials/post_meta.html
@@ -6,7 +6,7 @@
 {{ if .Site.Params.readingTime }} <!-- Add a separator between readingTime and WordCount if readingTime is enabled -->
 &nbsp;| &nbsp;
 {{ end }}
-<i class="fas fa-book"></i>&nbsp;{{ .WordCount }}&nbsp;{{ i18n "words" }}
+<span aria-label="Word count:"><span class="fas fa-book" aria-hidden="true"></span></span>&nbsp;{{ .WordCount }}&nbsp;{{ i18n "words" }}
 {{ end }}
 {{ if not .Site.Params.hideAuthor }}
 {{ if isset .Params "author" }}

--- a/layouts/partials/post_meta.html
+++ b/layouts/partials/post_meta.html
@@ -13,7 +13,7 @@
 {{ if or (.Site.Params.wordCount) (.Site.Params.readingTime)  }} <!-- Add a separator before author if either readingTime or  WordCount is enabled -->
 &nbsp;|&nbsp;
 {{ end }}
-<i class="fas fa-user"></i>&nbsp;
+<span aria-label="Author:"><span class="fas fa-user" aria-hidden="true"></span></span>&nbsp;
 {{ if isset .Params "authorlink" }}
 <a href="{{ relURL .Params.authorlink }}" target="_blank" rel="noopener noreferrer">{{ .Params.author | safeHTML }}</a>
 {{ else }}

--- a/layouts/partials/post_meta.html
+++ b/layouts/partials/post_meta.html
@@ -1,6 +1,6 @@
 <span class="post-meta">
 {{ if .Site.Params.readingTime }}
-&nbsp;<i class="fas fa-clock"></i>&nbsp;{{ .ReadingTime }}&nbsp;{{ i18n "minutes" }}
+&nbsp;<span aria-label="Reading time:"><span class="fas fa-clock" aria-hidden="true"></span></span>&nbsp;{{ .ReadingTime }}&nbsp;{{ i18n "minutes" }}
 {{ end }}
 {{ if .Site.Params.wordCount }}
 {{ if .Site.Params.readingTime }} <!-- Add a separator between readingTime and WordCount if readingTime is enabled -->

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -436,6 +436,10 @@ table th {
   margin: 0 0 10px;
 }
 
+.description {
+  margin: 0;
+}
+
 .pagination {
     margin: 0;
     padding: 0;

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -92,6 +92,12 @@ header nav li {
   padding: 0;
 }
 
+#dark-mode {
+  padding: 0;
+  border: none;
+  background: none;
+}
+
 footer {
   font-family: "Roboto Slab Regular", serif;
   text-align: right;

--- a/static/js/dark-mode.js
+++ b/static/js/dark-mode.js
@@ -1,12 +1,12 @@
-const toggleSwitch = document.querySelector('i.dark-mode.icons.fas');
+const toggleSwitch = document.querySelector('#dark-mode');
 var currentTheme = localStorage.getItem('theme');
 
 if (currentTheme) {
     document.documentElement.setAttribute('data-theme', currentTheme);
 
     if (currentTheme === 'dark') {
-        document.querySelector('i.dark-mode.icons.fas').classList.remove('fa-moon');
-        document.querySelector('i.dark-mode.icons.fas').classList.add('fa-sun');
+        document.querySelector('#dark-mode .icons.fas').classList.remove('fa-moon');
+        document.querySelector('#dark-mode .icons.fas').classList.add('fa-sun');
     }
 } else {
     currentTheme = localStorage.setItem('theme', 'light')
@@ -18,14 +18,14 @@ function switchTheme() {
         document.documentElement.setAttribute('data-theme', 'dark');
         localStorage.setItem('theme', 'dark');
         currentTheme = localStorage.getItem('theme');
-        document.querySelector('i.dark-mode.icons.fas').classList.remove('fa-moon');
-        document.querySelector('i.dark-mode.icons.fas').classList.add('fa-sun');
+        document.querySelector('#dark-mode .icons.fas').classList.remove('fa-moon');
+        document.querySelector('#dark-mode .icons.fas').classList.add('fa-sun');
     } else {
         document.documentElement.setAttribute('data-theme', 'light');
         localStorage.setItem('theme', 'light');
         currentTheme = localStorage.getItem('theme');
-        document.querySelector('i.dark-mode.icons.fas').classList.remove('fa-sun');
-        document.querySelector('i.dark-mode.icons.fas').classList.add('fa-moon');
+        document.querySelector('#dark-mode .icons.fas').classList.remove('fa-sun');
+        document.querySelector('#dark-mode .icons.fas').classList.add('fa-moon');
     }
 }
 


### PR DESCRIPTION
Some small tweaks that improve accessibility with screen readers a bit. Using `aria-hidden` with Font Awesome is recommended, as a screen reader wouldn't have an idea how to read the icons, see https://fontawesome.com/docs/web/dig-deeper/accessibility.

This also changes dark mode link into a button, which means that it would work with sequential navigation using Tab.

None of those changes should be user visible with a regular web browser.