### PR TITLE
Support optional full articles in the RSS feed

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -101,6 +101,7 @@ The following options for `class=` are available: right, alignright, left and al
  - **.Site.Params.excludedTypes** # Exclude specific types in lists
  - **.Site.Params.mainSections** # Add list of sections that should show up on the homepage
  - **.Site.Params.nofeedSections** # Add list of sections/types that should not be considered by RSS
+ - **.Site.Params.fullRSS** # Use a full HTML representation of the articles in the RSS feed
  - **.Site.Params.disableTaxoTypes** # Deactivate taxonomies for specific page types
  - **.Site.Params.favicon** # Activate favicons for the website
  - **.Site.Params.comments.enabled** # Enable/Disable comments for website entirely

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -46,7 +46,11 @@
 			{{- if isset .Params "description" }}
 			{{ .Description }}
 			{{- else }}
+			{{- if .Site.Params.fullRSS }}
+			{{ .Content | html }}
+			{{- else }}
 			{{ .Plain | htmlUnescape | safeHTML | truncate 140 }}
+			{{- end }}
 			{{- end }}
 			</description>
 		</item>


### PR DESCRIPTION
This allows to include the complete article in the RSS feed. This beneficial if your blog is not depended on the clicks, but you want to offer your power users a nice article view in their RSS reader