### PR TITLE
Fixed customcss not being injected into 'index.html'

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -19,3 +19,4 @@ collaboration of others.
 * [Jeff Schoner](https://github.com/jeffschoner)
 * [Leo Qi](https://github.com/leozqi)
 * [Konrad Borowski](https://github.com/xfix)
+* [Peter D. Faria](https://github.com/zshift)

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -48,8 +48,8 @@ localStorage.setItem('theme', 'dark');
 {{ printf "src=%q" (.Site.Params.customjs.src | relURL) | safeHTMLAttr }}>
 </script>
 {{- end }}
-{{- if isset .Site.Params "customcss" }}
-<link rel="stylesheet" type="text/css" media="screen" href="{{ relURL .Site.Params.customCSS }}" />
+{{ range .Site.Params.customcss -}}
+<link rel="stylesheet" type="text/css" media="screen" href="{{ . | relURL }}">
 {{- end }}
 {{- with .OutputFormats.Get "rss" }}
 {{ printf `<link rel="%s" type="%s" href="%s" title="%s">` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}


### PR DESCRIPTION
Fixes #92 

`customcss` can be set to an array of css files, and the solution also works when `customcss` is not set in params. Previously, setting this value did not result in customcss being added to `index.html`.