### PR TITLE
Add support for Isso comment engine

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -105,10 +105,11 @@ The following options for `class=` are available: right, alignright, left and al
  - **.Site.Params.disableTaxoTypes** # Deactivate taxonomies for specific page types
  - **.Site.Params.favicon** # Activate favicons for the website
  - **.Site.Params.comments.enabled** # Enable/Disable comments for website entirely
- - **.Site.Params.comments.engine** # Either disqus or commento to choose from
+ - **.Site.Params.comments.engine** # Either disqus, commento or isso to choose from
  - **.Site.Params.comments.disableOnTypes** # Deactivate comments for specific page types
  - **.Site.Params.comments.disqus.shortname** # New param for the shortname of a disqus instance
  - **.Site.Params.comments.commento.host** # Domain http/s of commento.io system of choice
+ - **.Site.Params.comments.isso.host** # Domain of your chosen Isso instance
 
 ## Front matter options for content
 

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -103,6 +103,7 @@ enabled = false
 # Comment provider:
 #   disqus (https://disqus.com)
 #   commento (https://commento.io)
+#   isso (https://isso-comments.de/)
 #engine = "disqus"
 
 # Content types to disable comments on.
@@ -113,6 +114,9 @@ enabled = false
 
 [params.comments.commento]
 #host = "" # Paste the domain of you commento.io system
+
+[params.comments.isso]
+#host = "" # Enter the domain of your Isso instance
 
 # Navigation
 [[menu.main]]

--- a/layouts/partials/comments.html
+++ b/layouts/partials/comments.html
@@ -2,4 +2,6 @@
 {{ partial "comments/disqus.html" . }}
 {{- else if eq site.Params.comments.engine "commento" }}
 {{ partial "comments/commento.html" . }}
+{{- else if eq site.Params.comments.engine "isso" }}
+{{ partial "comments/isso.html" . }}
 {{- end }}

--- a/layouts/partials/comments/isso.html
+++ b/layouts/partials/comments/isso.html
@@ -1,0 +1,5 @@
+<script data-isso="//{{ .Site.Params.comments.isso.host }}/"
+        src="//{{ .Site.Params.comments.isso.host }}/js/embed.min.js"></script>
+<section id="isso-thread">
+    <noscript>{{ i18n "nojscomments" }}</noscript>
+</section>

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -569,6 +569,14 @@ p code {
   float: right;
 }
 
+#isso-thread input {
+  background-color: var(--fn-color);
+}
+
+#isso-thread textarea {
+  background-color: var(--fn-color);
+}
+
 @media screen and (max-width: 800px) {
   body {
     margin: 0 auto;


### PR DESCRIPTION
Adds support for the [Isso](https://isso-comments.de/) comment engine

I took the snippet for embedding a comment section from [Isso's  guide](https://isso-comments.de/docs/guides/quickstart/#integration)

The comment section looked horrible on dark mode, so I added some CSS to fix it, and in my opinion it looks nice (screenshot below). I'm not sure if I added the CSS in the correct place or if the colors I chose align well with the theme, so if anyone has some notes I'd be happy to make changes.

![image](https://github.com/user-attachments/assets/401a95b6-4ae5-403f-bd75-f54537106531)